### PR TITLE
.gitignore: add cmake, build artifacts, and vim swap files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,10 @@
+*.swp
+CPackConfig.cmake
+CPackSourceConfig.cmake
 CMakeCache.txt
 CMakeFiles
 Makefile
 cmake_install.cmake
 install_manifest.txt
+libad9361.pc
+libad9361.so*


### PR DESCRIPTION
Newer versions of cmake seem to generate new build
artifacts.
This shows up at least with cmake version 3.7.2 (on Ubuntu 17.04).

Also, it should be a good idea to ignore generated libs
and .pc file.

Vim swap files are notorious for being added by accident.

Signed-off-by: Alexandru Ardelean <alex.ardelean@analog.com>