### PR TITLE
CI/travis/before_install_linux: pull actual latest libiio

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -10,5 +10,5 @@ brew install doxygen
 brew install --build-from-source libusb
 brew install libxml2
 
-wget http://swdownloads.analog.com/cse/travis_builds/latest_libiio${LDIST}.pkg
-sudo installer -pkg latest_libiio${LDIST}.pkg -target /
+wget http://swdownloads.analog.com/cse/travis_builds/master_latest_libiio${LDIST}.pkg
+sudo installer -pkg master_latest_libiio${LDIST}.pkg -target /

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -7,10 +7,10 @@ if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
 fi
 
 if [ `lsb_release -da 2>&1 | grep -i precise | wc -l` -gt 0 ] ; then
-	wget http://swdownloads.analog.com/cse/travis_builds/latest_libiio-precise.deb
-	mv ./latest_libiio-precise.deb ./latest_libiio.deb
+	wget http://swdownloads.analog.com/cse/travis_builds/master_latest_libiio-precise.deb
+	mv ./master_latest_libiio-precise.deb ./latest_libiio.deb
 else
-	wget http://swdownloads.analog.com/cse/travis_builds/latest_libiio-trusty.deb
-	mv ./latest_libiio-trusty.deb ./latest_libiio.deb
+	wget http://swdownloads.analog.com/cse/travis_builds/master_latest_libiio-trusty.deb
+	mv ./master_latest_libiio-trusty.deb ./latest_libiio.deb
 fi
 sudo apt install ./latest_libiio.deb


### PR DESCRIPTION
Currently Precise builds fail with error:
```
The following packages have unmet dependencies:
 libiio : Depends: libxml2 (>= 2.8.0~precise1) but 2.7.8.dfsg-5.1ubuntu4.17 is to be installed
E: Unable to correct problems, you have held broken packages.
```

After taking a closer look, it seems that the actual libiio version that
was pulled was 0.9 (which is the version in `latest_libiio-precise.deb`
 and the libiio build would always deploy a file named
`master_latest_libiio-precise.deb` (which contains the latest build on
master).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>