### PR TITLE
test/CMakeLists.txt: specifically link libiio to tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,11 +1,11 @@
 add_executable(FilterDesignerTest filter_designer_test.c)
-target_link_libraries(FilterDesignerTest ad9361)
+target_link_libraries(FilterDesignerTest ad9361 iio)
 add_test(NAME FilterDesignerTest
          COMMAND FilterDesignerTest
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(GenerateRatesTest gen_rates_test.c)
-target_link_libraries(GenerateRatesTest ad9361)
+target_link_libraries(GenerateRatesTest ad9361 iio)
 add_test(NAME GenerateRatesTest
          COMMAND GenerateRatesTest
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
In certain conditions/linker configuration, libiio needs to be explicitly
be specified.
Otherwise underlinking won't work too well.

This happened when building libad9361-iio with a different install prefix.
But in any case, it doesn't hurt to have libiio specified in the tests
linker libs.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>