### PR TITLE
test/CMakeLists.txt: specifically link libiio to tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,19 +1,17 @@
 add_executable(FilterDesignerTest filter_designer_test.c)
-target_link_libraries(FilterDesignerTest ad9361)
+target_link_libraries(FilterDesignerTest LINK_PRIVATE ${LIBIIO_LIBRARIES} ad9361)
 add_test(NAME FilterDesignerTest
          COMMAND FilterDesignerTest
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
 add_executable(GenerateRatesTest gen_rates_test.c)
-target_link_libraries(GenerateRatesTest ad9361)
+target_link_libraries(GenerateRatesTest LINK_PRIVATE ${LIBIIO_LIBRARIES} ad9361)
 add_test(NAME GenerateRatesTest
          COMMAND GenerateRatesTest
          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
 
-if (NOT WIN32)
- add_executable(FilterDesignerHardwareTest filter_designer_hw.c)
- target_link_libraries(FilterDesignerHardwareTest ad9361 iio)
- add_test(NAME FilterDesignerHardwareTest
-          COMMAND FilterDesignerHardwareTest
-          WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
-endif()
+add_executable(FilterDesignerHardwareTest filter_designer_hw.c)
+target_link_libraries(FilterDesignerHardwareTest LINK_PRIVATE ${LIBIIO_LIBRARIES} ad9361)
+add_test(NAME FilterDesignerHardwareTest
+         COMMAND FilterDesignerHardwareTest
+         WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})


### PR DESCRIPTION
In certain conditions/linker configuration, libiio needs to be explicitly
be specified.
Otherwise underlinking won't work too well.

This seems to happen when building libad9361-iio with a different install
prefix.

And from the looks of it, in appveyor we also need to specify this for
stuff to link to tests.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>