### PR TITLE
ad9361_multichip_sync: Switch to nanosleep to replace deprecated usleep

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -52,7 +52,7 @@ if (NOT WIN32)
 	set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fvisibility=hidden")
 endif()
 
-add_definitions(-DLIBAD9361_EXPORTS=1)
+add_definitions(-D_POSIX_C_SOURCE=199309L -DLIBAD9361_EXPORTS=1)
 
 set(INSTALL_LIB_DIR "${CMAKE_INSTALL_PREFIX}/lib"
 	CACHE PATH "Installation directory for libraries")

--- a/ad9361_multichip_sync.c
+++ b/ad9361_multichip_sync.c
@@ -21,9 +21,23 @@
 #include <windows.h>
 #else
 #include <unistd.h>
+#include <time.h>
 #endif
 
 #define MAX_AD9361_SYNC_DEVS	4
+
+static void ad9361_sleep_ms(void)
+{
+#ifdef _WIN32
+	Sleep(1); /* milliseconds */
+#else
+	struct timespec time;
+
+	time.tv_sec = 0;
+	time.tv_nsec = 1000 * 1000;
+	nanosleep(&time, NULL);
+#endif
+}
 
 int ad9361_multichip_sync(struct iio_device *master, struct iio_device **slaves,
 		unsigned int num_slaves, unsigned int flags)
@@ -90,11 +104,7 @@ int ad9361_multichip_sync(struct iio_device *master, struct iio_device **slaves,
 		else
 			iio_device_attr_write_longlong(master, "multichip_sync", step);
 
-#ifdef _WIN32
-		Sleep(1);
-#else
-		usleep(1000);
-#endif
+		ad9361_sleep_ms();
 	}
 
 	iio_device_attr_write(master, "ensm_mode", ensm_mode[0]);


### PR DESCRIPTION

4.3BSD,  POSIX.1-2001. POSIX.1-2001  declares  this  function obsolete;
use nanosleep(2) instead.  POSIX.1-2008 removes the specification
of usleep().Replace deprecated usleep

This fixes issue #20

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>