### PR TITLE
Enable tests on all platforms

### DIFF
--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -6,8 +6,10 @@ cd $TRAVIS_BUILD_DIR/build
 cmake -DOSX_PACKAGE=ON ..
 make
 ls
+make test
 
 cd $TRAVIS_BUILD_DIR/build_tar
 cmake -DOSX_PACKAGE=OFF -DENABLE_PACKAGING=ON ..
 make && make package
 ls
+make test

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -5,4 +5,4 @@ if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 cd $TRAVIS_BUILD_DIR/build
 cmake -DENABLE_PACKAGING=ON -DDEB_DETECT_DEPENDENCIES=ON ..
 make && make package
-
+make test

--- a/ad9361_calculate_rf_clock_chain.c
+++ b/ad9361_calculate_rf_clock_chain.c
@@ -59,10 +59,12 @@ bool check_rates(int FIR, const int *HB_configs, unsigned long samp_rate,
 int determine_pll_div(unsigned long *rates)
 {
     // Determine necessary PLL multiplier
+    unsigned long long tmp;
     int PLL_mult = MAX_BBPLL_DIV;
     while (PLL_mult>1) {
-        rates[0] = (unsigned long) rates[1]*PLL_mult;
-        if (check(rates[0], MIN_BBPLL_FREQ, MAX_BBPLL_FREQ)) {
+        tmp = (unsigned long long) rates[1]*PLL_mult;
+        if (check(tmp, MIN_BBPLL_FREQ, MAX_BBPLL_FREQ)) {
+            rates[0] = (unsigned long) rates[1]*PLL_mult;
             return PLL_mult;
         }
         PLL_mult >>= 1;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -48,6 +48,9 @@ build_script:
         -DCMAKE_MAKE_PROGRAM=c:/msys64/mingw32/bin/mingw32-make.exe \
         ..
     - cmake --build . --config Release
+    - copy c:\libiio-mingw-win32\*.dll c:\projects\libad9361-iio\build-mingw-win32\test\
+    - copy c:\projects\libad9361-iio\build-mingw-win32\*.dll c:\projects\libad9361-iio\build-mingw-win32\test\
+    - ctest -V -R
 
     # 64-bit build - MinGW
     - mkdir c:\projects\libad9361-iio\build-mingw-win64
@@ -61,7 +64,9 @@ build_script:
         -DCMAKE_MAKE_PROGRAM=c:/msys64/mingw64/bin/mingw32-make.exe \
         ..
     - cmake --build . --config Release
-
+    - copy c:\libiio-mingw-win64\*.dll c:\projects\libad9361-iio\build-mingw-win64\test\
+    - copy c:\projects\libad9361-iio\build-mingw-win64\*.dll c:\projects\libad9361-iio\build-mingw-win64\test\
+    - ctest -V -R
 
     # 32-bit build - VS
     - mkdir c:\projects\libad9361-iio\build-win32
@@ -72,6 +77,9 @@ build_script:
         -DCMAKE_CONFIGURATION_TYPES=Release \
         ..
     - cmake --build . --config Release
+    - copy c:\libiio-win32\*.dll c:\projects\libad9361-iio\build-win32\test\Release
+    - copy c:\projects\libad9361-iio\build-win32\Release\*.dll c:\projects\libad9361-iio\build-win32\test\Release
+    - ctest -V -C Release
 
     # 64-bit build - VS
     - mkdir c:\projects\libad9361-iio\build-win64
@@ -82,7 +90,10 @@ build_script:
         -DCMAKE_CONFIGURATION_TYPES=Release \
         ..
     - cmake --build . --config Release
-
+    - copy c:\libiio-win64\*.dll c:\projects\libad9361-iio\build-win64\test\Release
+    - copy c:\projects\libad9361-iio\build-win64\Release\*.dll c:\projects\libad9361-iio\build-win64\test\Release
+    - ctest -V -C Release
+    
     #Create the installer
     - ISCC c:\projects\libad9361-iio\build-win64\libad9361-iio.iss
     - appveyor PushArtifact C:\libad9361-setup.exe


### PR DESCRIPTION
This PR enables testing for top level functions:
- ad9361_calculate_rf_clock_chain
- ad9361_calculate_rf_clock_chain_fdp
- ad9361_generate_fir_taps

Hardware specific tests are disabled unless the necessary hardware is attached. These functions include: 
- ad9361_set_bb_rate_custom_filter_auto
- ad9361_set_bb_rate_custom_filter_manual


Included are some fixes the tests found, primarily when compiling on Windows.