### PR TITLE
ad9361_baseband_auto_rate: Fix low rate filter enable

### DIFF
--- a/ad9361_baseband_auto_rate.c
+++ b/ad9361_baseband_auto_rate.c
@@ -143,6 +143,23 @@ int ad9361_set_bb_rate(struct iio_device *dev, unsigned long rate)
 		return ret;
 
 	if (rate <= (25000000 / 12))  {
+		int dacrate, txrate, max;
+		char readbuf[100];
+
+		ret = iio_device_attr_read(dev, "tx_path_rates", readbuf, sizeof(readbuf));
+		if (ret < 0)
+			return ret;
+		ret = sscanf(readbuf, "BBPLL:%*d DAC:%d T2:%*d T1:%*d TF:%*d TXSAMP:%d", &dacrate, &txrate);
+		if (ret != 2)
+			return -EFAULT;
+
+		if (txrate == 0)
+			return -EINVAL;
+
+		max = (dacrate / txrate) * 16;
+		if (max < taps)
+			iio_channel_attr_write_longlong(chan, "sampling_frequency", 3000000);
+
 		ret = ad9361_set_trx_fir_enable(dev, true);
 		if (ret < 0)
 			return ret;


### PR DESCRIPTION
Rates < 2.08 MSPS require the decimation in the FIR filter.
Under some circumstances, the loaded filter fails to enable due to
constrains enforced by the driver. Check the number of supported
taps for the current rate, and if the loaded filter has more taps than
supported, lower the base-band rate.

Signed-off-by: Michael Hennerich <michael.hennerich@analog.com>