### PR TITLE
MATLAB appveyor updates

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -103,6 +103,7 @@ build_script:
 
     - mkdir c:\libad9361-win32
     - copy ad9361.h c:\libad9361-win32\
+    - copy bindings\matlab\ad9361-wrapper.h c:\libad9361-win32\
     - copy build-win32\Release\libad9361.* c:\libad9361-win32\
     - copy c:\libiio-win32\*.dll c:\libad9361-win32\
     - 7z a "c:\libad9361-win32.zip" c:\libad9361-win32
@@ -110,6 +111,7 @@ build_script:
 
     - mkdir c:\libad9361-win64
     - copy ad9361.h c:\libad9361-win64\
+    - copy bindings\matlab\ad9361-wrapper.h c:\libad9361-win64\
     - copy build-win64\Release\libad9361.* c:\libad9361-win64\
     - copy c:\libiio-win64\*.dll c:\libad9361-win64\
     - 7z a "c:\libad9361-win64.zip" c:\libad9361-win64
@@ -117,6 +119,7 @@ build_script:
 
     - mkdir c:\libad9361-mingw-win32
     - copy ad9361.h c:\libad9361-mingw-win32\
+    - copy bindings\matlab\ad9361-wrapper.h c:\libad9361-mingw-win32\
     - copy build-mingw-win32\libad9361.* c:\libad9361-mingw-win32\
     - copy c:\libiio-mingw-win32\*.dll c:\libad9361-mingw-win32\
     - 7z a "c:\libad9361-mingw-win32.zip" c:\libad9361-mingw-win32
@@ -124,6 +127,7 @@ build_script:
 
     - mkdir c:\libad9361-mingw-win64
     - copy ad9361.h c:\libad9361-mingw-win64\
+    - copy bindings\matlab\ad9361-wrapper.h c:\libad9361-mingw-win64\
     - copy build-mingw-win64\libad9361.* c:\libad9361-mingw-win64\
     - copy c:\libiio-mingw-win64\*.dll c:\libad9361-mingw-win64\
     - 7z a "c:\libad9361-mingw-win64.zip" c:\libad9361-mingw-win64

--- a/libad9361-iio.iss.cmakein
+++ b/libad9361-iio.iss.cmakein
@@ -53,6 +53,7 @@ Source: "C:\projects\libad9361-iio\build-win64\test\Release\*.exe"; DestDir: "{s
 Source: "C:\projects\libad9361-iio\build-win32\Release\libad9361.lib"; DestDir: "{pf32}\Microsoft Visual Studio 12.0\VC\lib"; Check: not Is64BitInstallMode
 Source: "C:\projects\libad9361-iio\build-win64\Release\libad9361.lib"; DestDir: "{pf32}\Microsoft Visual Studio 12.0\VC\lib\amd64"; Check: Is64BitInstallMode
 Source: "C:\projects\libad9361-iio\ad9361.h"; DestDir: "{pf32}\Microsoft Visual Studio 12.0\VC\include"
+Source: "C:\projects\libad9361-iio\bindings\matlab\ad9361-wrapper.h"; DestDir: "{pf32}\Microsoft Visual Studio 12.0\VC\include"
 
 Source: "C:\libiio-win32\libiio.dll"; DestDir: "{sys}"; Flags: onlyifdoesntexist 32bit
 Source: "C:\libiio-win64\libiio.dll"; DestDir: "{sys}"; Check: Is64BitInstallMode; Flags: onlyifdoesntexist


### PR DESCRIPTION
This PR updates appveyor to include the new MATLAB bindings header to the installer and built artifacts.