### PR TITLE
build,.travis.yml: drop xcode 8 build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,9 +41,6 @@ matrix:
         - OS_VERSION=bionic
     - compiler: "gcc"
       os: osx
-      osx_image: xcode8
-    - compiler: "gcc"
-      os: osx
       osx_image: xcode9.2
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss


### PR DESCRIPTION
Support for Xcode 8 in libiio has been dropped.
This change updates the pipeline in libad9361-iio to remove Xcode 8 as
well.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>