### PR TITLE
CI/travis/after_deploy: trigger `gr-iio` build when done

### DIFF
--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -4,4 +4,5 @@
 
 should_trigger_next_builds "$TRAVIS_BRANCH" || exit 0
 
+trigger_adi_build "gr-iio" "$TRAVIS_BRANCH"
 trigger_adi_build "iio-oscilloscope" "$TRAVIS_BRANCH"


### PR DESCRIPTION
The build path here is towards building Scopy.
After `libad9361-iio` is done, this will also trigger `gr-iio`.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>