### PR TITLE
ci,os-x: reduce build times by not upgrading

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -2,7 +2,7 @@
 
 . CI/travis/lib.sh
 
-brew_install_or_upgrade cmake doxygen libusb libxml2
+brew_install_if_not_exists cmake doxygen libusb libxml2
 
 wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg
 sudo installer -pkg ${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg -target /


### PR DESCRIPTION
Travis-CI OS X images have plenty of stuff installed. And they are updated
every now-n-then. Running `brew upgrade` can take too much on older images.

So, don't upgrade packages. Just use the ones installed.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>