### PR TITLE
ci,build: various updates

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,9 @@ services:
 
 matrix:
   include:
-    - compiler: "clang"
+    - stage: "Build & Deploy"
+
+      compiler: "clang"
       os: linux
       env: LDIST=DO_NOT_DEPLOY
     - compiler: "gcc"
@@ -54,6 +56,10 @@ matrix:
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
 
+    - stage: "Trigger Next In Pipeline"
+      env:
+        - TRIGGER_NEXT_BUILD=true
+
 addons:
   artifacts: true
   ssh_known_hosts:
@@ -69,6 +75,7 @@ before_install:
 script:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_linux libad9361-iio "$OS_TYPE" "$OS_VERSION" ; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/make_darwin; fi
+  - if [[ "$TRIGGER_NEXT_BUILD" == "true" ]]; then ${TRAVIS_BUILD_DIR}/CI/travis/after_deploy; fi
 
 notifications:
   email:
@@ -119,6 +126,3 @@ deploy:
     on:
       condition: "$TRAVIS_OS_NAME = osx"
       all_branches: true
-
-after_deploy:
-  - ${TRAVIS_BUILD_DIR}/CI/travis/after_deploy

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,11 +42,6 @@ matrix:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
-      osx_image: xcode9.2
-      env:
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
-    - compiler: "gcc"
-      os: osx
       osx_image: xcode10.1
       env:
         - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,5 +1,7 @@
 #!/bin/sh -xe
 
+TRIGGERING_NEXT_BUILD=true
+
 . CI/travis/lib.sh
 
 should_trigger_next_builds "$TRAVIS_BRANCH" || exit 0

--- a/CI/travis/after_deploy
+++ b/CI/travis/after_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 TRIGGERING_NEXT_BUILD=true
 

--- a/CI/travis/before_deploy
+++ b/CI/travis/before_deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/deploy
+++ b/CI/travis/deploy
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 . CI/travis/lib.sh
 

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 TRAVIS_BUILD_DIR=${TRAVIS_BUILD_DIR:-'./'}
 

--- a/CI/travis/make_darwin
+++ b/CI/travis/make_darwin
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -1,4 +1,4 @@
-#!/bin/sh -xe
+#!/bin/sh -e
 
 if [ "x${COVERITY_SCAN_PROJECT_NAME}" != "x" ] ; then exit 0; fi
 


### PR DESCRIPTION
The build here got a bit neglected.

1. Dropping build for Xcode 9.2 ; was dropped for libiio a while ago
2. Removed -x shell specifier; not needed for now
3. More importantly: move the triggering of next builds into separate stage same as https://github.com/analogdevicesinc/libiio/pull/417

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>