### PR TITLE
Update HW test to use environmental variables

### DIFF
--- a/test/auto_rate_test_hw.c
+++ b/test/auto_rate_test_hw.c
@@ -52,7 +52,9 @@ int main(void)
 
     unsigned long rates[] = {520888, 600000, 1000000, 10000000, 20000000, 40000000, 60000000};
 
-    char * uri = "ip:192.168.2.1";
+    const char* uri = getenv("URI_AD9361");
+    if (uri == NULL)
+        exit(0);// Cant find anything don't run tests
     ctx = iio_create_context_from_uri(uri);
     if (ctx == NULL) {
         printf("No device found... skipping test");

--- a/test/filter_designer_hw.c
+++ b/test/filter_designer_hw.c
@@ -22,13 +22,15 @@ int main(void)
 
     unsigned long rates[] = {1000000, 10000000, 20000000, 60000000};
 
-    char * uri = "ip:192.168.2.1";
+    const char* uri = getenv("URI_AD9361");
+    if (uri == NULL)
+        exit(0);// Cant find anything don't run tests
     ctx = iio_create_context_from_uri(uri);
     if (ctx == NULL)
         exit(0);// Cant find anything don't run tests
     dev = iio_context_find_device(ctx, "ad9361-phy");
 
-    for (k = 0; k < 1; k++) {
+    for (k = 0; k < 3; k++) {
 
         printf("Testing rate: %lu\n",rates[k]);
 

--- a/test/fmcomms5_sync_test.c
+++ b/test/fmcomms5_sync_test.c
@@ -204,7 +204,9 @@ int main(void)
 {
     // Set up context
     struct iio_context *ctx;
-    char * uri = "ip:192.168.1.208";
+    const char* uri = getenv("URI_FMCOMMS5");
+    if (uri == NULL)
+        exit(0);// Cant find anything don't run tests
     ctx = iio_create_context_from_uri(uri);
     if (ctx==NULL)
         exit(0);// Cant find anything don't run tests


### PR DESCRIPTION
This PR is designed to make the library testable with the hardware testing harness where URIs are parameterizable.
This branch has been running fine in the harness for ~2 weeks. 

Signed-off-by: Travis F. Collins <travis.collins@analog.com>