### PR TITLE
ci,travis: add CentOS 8 & Ubuntu 20.04 builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ cmake_install.cmake
 install_manifest.txt
 libad9361.pc
 libad9361.so*
+build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ sudo: required
 
 env:
   global:
+  - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
   # SSHHOST
   - secure: "Izx3rvvdDSlv26z0OLsyHj6uN5YoOz/Deg0bLx8IHRqPcRULJlQLqXOaeX41DmsltFq1X8AbVW2TmqzaLHnsGfM76IyqIWVLANC0TcevKyonDujkiuWoFDrYciKJyLS2aN4SgnG4jyp9977Z0Vc5EL9D61QDlh3LUU+x3+CYxQIWWpMoOsfyZUw8FU/b/KmjqE7zvtgN/RMAeuDIn7jLP9Yg9pFB8KnOFyWHSfT5cXux4WSYqwQasYf68+3JyuJSebS3kK/FgCJOODMs+xed9BjeP8QinhmXFdy+epIFXLARUKZrLzj9+94PZ8n0m0TV39yqFfk96qRjM4bJNwCqfUU6iaSsuLNlSU2HbQeqSDW//BsXFL3EicM+7xgYnx/luboLQZgqJYQAPk3ihaH456Gl9PNF6h4zv8vXsHE+nHDZvubwsgNdTk25YP+3GglQZdRHBhsdBSASGYc0CxYwPHsBi4/QD0RQ2k0W4D1dwJXXRXxTqoSfveP8QIsQVfDwfAhWLG9QMjVwp1dMl+5wIp25E4v1C2I2rQJVuc7pjPb/av34ltWBlQwcXkxUl3/E3qDrO4b5gS/UD47bRCCqYf9GLniXVBm7z+ebA7tW4G/q/RJvb3G7q59nAJXSwJOvB5Kt3pnfeCmfgv6wGeeNizQer+AjHkQy1uNQBBSI8Jw="
   # SSHUSER
@@ -23,33 +24,28 @@ matrix:
     - compiler: "gcc"
       os: linux
       dist: xenial
-      env:
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=6
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
         - OS_TYPE=centos_docker
         - OS_VERSION=7
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - os: linux
       env:
-        - OS_TYPE=ubuntu_docker
-        - OS_VERSION=bionic
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
+        - OS_TYPE=centos_docker
+        - OS_VERSION=8
+    - os: linux
+      dist: bionic
+    - os: linux
+      dist: focal
     - compiler: "gcc"
       os: osx
       osx_image: xcode10.1
-      env:
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
     - compiler: "gcc"
       os: osx
       osx_image: xcode11
-      env:
-        - EXTRA_SSH=-oHostKeyAlgorithms=+ssh-dss
 
     - stage: "Trigger Next In Pipeline"
       env:

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -5,6 +5,13 @@
 handle_centos() {
 	# FIXME: see about adding `libserialport-dev` from EPEL ; maybe libusb-1.0.0-devel...
 	yum -y groupinstall 'Development Tools'
+
+	if is_centos_at_least_ver "8" ; then
+		# On CentOS 8, avahi-devel & doxygen are in this repo; enable it
+		yum -y install yum-utils
+		yum config-manager --set-enabled PowerTools
+	fi
+
 	yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
 		avahi-devel bzip2 gzip rpm rpm-build
 


### PR DESCRIPTION
Add CentOS 8 & Ubuntu 20.04 docker builds via Travis-CI infrastructure.
Globalize EXTRA_SSH env var. It's now in all docker images.
Add build/ folder to .gitignore.

For CentOS 8 we need to enable some extra repos.

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>