### PR TITLE
ci,azure-pipelines: use matrix strategy, and user artifacts from libiio's pipeline

### DIFF
--- a/CI/build_win.ps1
+++ b/CI/build_win.ps1
@@ -1,0 +1,18 @@
+
+$COMPILER=$Env:COMPILER
+$ARCH=$Env:ARCH
+
+$src_dir=$pwd
+
+if (!(Test-Path build)) {
+	mkdir build
+}
+cd build
+
+cmake -G "$COMPILER" -A "$ARCH" `
+        -DLIBIIO_LIBRARIES:FILEPATH=$pwd\libiio.lib `
+        -DLIBIIO_INCLUDEDIR:PATH=$pwd `
+        -DCMAKE_CONFIGURATION_TYPES=Release `
+	..
+
+cmake --build . --config Release

--- a/CI/install_deps_win.ps1
+++ b/CI/install_deps_win.ps1
@@ -1,0 +1,6 @@
+
+# Note: InnoSetup is already installed on Azure images; so don't run this step
+#       Running choco seems a bit slow; seems to save about 40-60 seconds here
+#choco install InnoSetup
+
+set PATH=%PATH%;"C:\Program Files (x86)\Inno Setup 6"

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -4,5 +4,7 @@
 
 brew_install_if_not_exists cmake doxygen libusb libxml2
 
-wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg
-sudo installer -pkg ${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg -target /
+if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+	wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg
+	sudo installer -pkg ${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg -target /
+fi

--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -4,7 +4,11 @@
 
 brew_install_if_not_exists cmake doxygen libusb libxml2
 
-if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+	for file in $PACKAGE_TO_INSTALL ; do
+		sudo installer -pkg "${file}" -target /
+	done
+elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 	wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg
 	sudo installer -pkg ${LIBIIO_BRANCH}_latest_libiio${LDIST}.pkg -target /
 fi

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -29,9 +29,9 @@ handle_generic_docker() {
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake doxygen graphviz libaio-dev libavahi-client-dev \
-		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip \
-		flex bison libserialport-dev
+	sudo DEBIAN_FRONTEND=noninteractive apt-get install -y cmake doxygen graphviz \
+		libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev \
+		libxml2-dev rpm tar bzip2 gzip flex bison libserialport-dev
 
 	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
 		sudo dpkg -i $PACKAGE_TO_INSTALL

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -15,7 +15,9 @@ handle_centos() {
 	yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
 		avahi-devel bzip2 gzip rpm rpm-build
 
-	if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+		sudo yum localinstall -y $PACKAGE_TO_INSTALL
+	elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 		wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
 		sudo yum localinstall -y ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
 	fi
@@ -36,7 +38,9 @@ handle_default() {
 		sudo apt-get install -y libserialport-dev
 	fi
 
-	if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
+		sudo dpkg -i $PACKAGE_TO_INSTALL
+	elif [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
 		wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
 		sudo dpkg -i ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
 	fi

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -15,8 +15,10 @@ handle_centos() {
 	yum -y install cmake libxml2-devel libusb1-devel doxygen libaio-devel \
 		avahi-devel bzip2 gzip rpm rpm-build
 
-	wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
-	sudo yum localinstall -y ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
+	if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+		wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
+		sudo yum localinstall -y ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.rpm
+	fi
 }
 
 handle_centos_docker() {
@@ -34,8 +36,10 @@ handle_default() {
 		sudo apt-get install -y libserialport-dev
 	fi
 
-	wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
-	sudo dpkg -i ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
+	if [ "$INSTALL_FROM_SW_DOWNLOADS" = "1" ] ; then
+		wget http://swdownloads.analog.com/cse/travis_builds/${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
+		sudo dpkg -i ./${LIBIIO_BRANCH}_latest_libiio${LDIST}.deb
+	fi
 }
 
 OS_TYPE=${OS_TYPE:-default}

--- a/CI/travis/before_install_linux
+++ b/CI/travis/before_install_linux
@@ -23,20 +23,15 @@ handle_centos() {
 	fi
 }
 
-handle_centos_docker() {
-	prepare_docker_image "centos:centos${OS_VERSION}"
-}
-
-handle_ubuntu_docker() {
-	prepare_docker_image "ubuntu:${OS_VERSION}"
+handle_generic_docker() {
+	prepare_docker_image
 }
 
 handle_default() {
 	sudo apt-get -qq update
-	sudo apt-get install -y cmake doxygen graphviz libaio-dev libavahi-client-dev libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip flex bison git
-	if [ `sudo apt-cache search libserialport-dev | wc -l` -gt 0 ] ; then
-		sudo apt-get install -y libserialport-dev
-	fi
+	sudo apt-get install -y cmake doxygen graphviz libaio-dev libavahi-client-dev \
+		libavahi-common-dev libusb-1.0-0-dev libxml2-dev rpm tar bzip2 gzip \
+		flex bison libserialport-dev
 
 	if [ -n "$PACKAGE_TO_INSTALL" ] ; then
 		sudo dpkg -i $PACKAGE_TO_INSTALL
@@ -46,6 +41,14 @@ handle_default() {
 	fi
 }
 
-OS_TYPE=${OS_TYPE:-default}
+handle_ubuntu() {
+	handle_default
+}
 
-handle_${OS_TYPE}
+handle_debian() {
+	handle_default
+}
+
+setup_build_type_env_vars
+
+handle_${BUILD_TYPE}

--- a/CI/travis/lib.sh
+++ b/CI/travis/lib.sh
@@ -41,6 +41,8 @@ ensure_command_exists sudo
 
 . ${TRAVIS_BUILD_DIR}/build/lib.sh
 
+INSIDE_DOCKER_TRAVIS_CI_ENV="$INSIDE_DOCKER_TRAVIS_CI_ENV PACKAGE_TO_INSTALL"
+
 if [ -z "${LDIST}" -a -f "build/.LDIST" ] ; then
 	export LDIST="-$(cat build/.LDIST)"
 fi

--- a/CI/travis/make_linux
+++ b/CI/travis/make_linux
@@ -20,16 +20,18 @@ handle_centos() {
 	cd ..
 }
 
-handle_centos_docker() {
-	run_docker_script inside_docker.sh \
-		"centos:centos${OS_VERSION}" "centos"
+handle_ubuntu() {
+	handle_default
 }
 
-handle_ubuntu_docker() {
-	run_docker_script inside_docker.sh \
-		"ubuntu:${OS_VERSION}"
+handle_debian() {
+	handle_default
 }
 
-OS_TYPE=${OS_TYPE:-default}
+handle_generic_docker() {
+	run_docker_script inside_docker.sh
+}
 
-handle_${OS_TYPE}
+setup_build_type_env_vars
+
+handle_${BUILD_TYPE}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,12 +10,46 @@ pr:
 - 20*
 
 jobs:
-- job: centos_7_x86_64
+- job: LinuxBuilds
+  strategy:
+    matrix:
+      centos_7_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'centos_docker'
+        OS_VERSION: centos7
+        artifactName: 'Linux-CentOS-7-x86_64'
+      centos_8_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'centos_docker'
+        OS_VERSION: centos8
+        artifactName: 'Linux-CentOS-8-x86_64'
+      ubuntu_16_04_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: xenial
+        artifactName: 'Linux-Ubuntu-16.04-x86_64'
+      ubuntu_18_04_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: bionic
+        artifactName: 'Linux-Ubuntu-18.04-x86_64'
+      ubuntu_20_04_x86_64:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'ubuntu_docker'
+        OS_VERSION: focal
+        artifactName: 'Linux-Ubuntu-20.04-x86_64'
+      debian_buster_arm32v7:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm32v7/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM'
+      debian_buster_arm64v8:
+        imageName: 'ubuntu-latest'
+        OS_TYPE: 'arm64v8/debian_docker'
+        OS_VERSION: 'buster'
+        artifactName: 'Linux-Debian-Buster-ARM64'
   pool:
-    vmImage: 'ubuntu-latest'
-  variables:
-    OS_TYPE: centos_docker
-    OS_VERSION: 7
+    vmImage: $(imageName)
   steps:
   - checkout: self
     fetchDepth: 1
@@ -24,95 +58,96 @@ jobs:
     displayName: "Install Dependencies"
   - script: ./CI/travis/make_linux
     displayName: "Build"
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+      contents: '$(Agent.BuildDirectory)/s/build/?(*.deb|*.rpm)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)'
 
-- job: centos_8_x86_64
-  pool:
-    vmImage: 'ubuntu-latest'
-  variables:
-    OS_TYPE: centos_docker
-    OS_VERSION: 8
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_16_04_x86_64
-  pool:
-    vmImage: 'ubuntu-16.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_18_04_x86_64
-  pool:
-    vmImage: 'ubuntu-18.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: ubuntu_20_04_x86_64
-  pool:
-    vmImage: 'ubuntu-20.04'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_linux
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_linux
-    displayName: "Build"
-
-- job: macos_10_14
-  pool:
-    vmImage: 'macos-10.14'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_darwin
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_darwin
-    displayName: "Build"
-
-- job: macos_10_15
-  pool:
-    vmImage: 'macos-10.15'
-  steps:
-  - checkout: self
-    fetchDepth: 1
-    clean: true
-  - script: ./CI/travis/before_install_darwin
-    displayName: "Install Dependencies"
-  - script: ./CI/travis/make_darwin
-    displayName: "Build"
-
+- job: macOSBuilds
+  strategy:
+    matrix:
+      macOS_10_14:
+        imageName: 'macOS-10.14'
+        artifactName: 'macOS-10.14'
+      macOS_10_15:
+        imageName: 'macOS-10.15'
+        artifactName: 'macOS-10.15'
 # FIXME: uncomment after this is resolved:
 #        https://github.com/actions/virtual-environments/issues/2072
 # Mac OS X 11.0 is definitely a big thing (with their switch to ARM,
 # so we should be quick to have it)
-#
-# - job: macos_11_0
-#  pool:
-#    vmImage: 'macos-11.0'
-#  steps:
-#  - checkout: self
-#    fetchDepth: 1
-#    clean: true
-#  - script: ./CI/travis/before_install_darwin
-#    displayName: "Install Dependencies"
-#  - script: ./CI/travis/make_darwin
-#    displayName: "Build"
+#      macOS_11_0:
+#        imageName: 'macOS-11.0'
+#        artifactName: 'macOS-11.0'
+  pool:
+    vmImage: $(imageName)
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - script: ./CI/travis/before_install_darwin
+    displayName: "Install Dependencies"
+  - script: ./CI/travis/make_darwin
+    displayName: "Build"
+  - task: CopyFiles@2
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/'
+      contents: '$(Agent.BuildDirectory)/s/build/?(*.pkg)'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)'
+
+- job: WindowsBuilds
+  strategy:
+    matrix:
+      VS2019_Win32:
+        imageName: 'windows-2019'
+        COMPILER: 'Visual Studio 16 2019'
+        ARCH: 'Win32'
+        artifactName: 'Windows-VS-16-2019-Win32'
+      VS2019_Win64:
+        imageName: 'windows-2019'
+        COMPILER: 'Visual Studio 16 2019'
+        ARCH: 'x64'
+        artifactName: 'Windows-VS-16-2019-x64'
+  pool:
+    vmImage: $[ variables['imageName'] ]
+  steps:
+  - checkout: self
+    fetchDepth: 1
+    clean: true
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: .\CI\install_deps_win.ps1
+    displayName: Dependencies
+  - task: PowerShell@2
+    inputs:
+      targetType: 'filePath'
+      filePath: .\CI\build_win.ps1
+    displayName: Build
+  - task: CopyFiles@2
+    displayName: 'Copy libraries'
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/build/Release'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: CopyFiles@2
+    displayName: 'Copy ad9361.h header'
+    inputs:
+      sourceFolder: '$(Agent.BuildDirectory)/s/'
+      contents: 'ad9361.h'
+      targetFolder: '$(Build.ArtifactStagingDirectory)'
+  - task: PublishPipelineArtifact@1
+    condition: and(succeeded(), ne(variables['Build.Reason'], 'PullRequest'))
+    inputs:
+      targetPath: '$(Build.ArtifactStagingDirectory)'
+      artifactName: '$(artifactName)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  libiioPipelineId: 9
+
 trigger:
 - main
 - master
@@ -18,42 +21,58 @@ jobs:
         OS_TYPE: 'centos_docker'
         OS_VERSION: centos7
         artifactName: 'Linux-CentOS-7-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.rpm'
       centos_8_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'centos_docker'
         OS_VERSION: centos8
         artifactName: 'Linux-CentOS-8-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.rpm'
       ubuntu_16_04_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'ubuntu_docker'
         OS_VERSION: xenial
         artifactName: 'Linux-Ubuntu-16.04-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
       ubuntu_18_04_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'ubuntu_docker'
         OS_VERSION: bionic
         artifactName: 'Linux-Ubuntu-18.04-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
       ubuntu_20_04_x86_64:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'ubuntu_docker'
         OS_VERSION: focal
         artifactName: 'Linux-Ubuntu-20.04-x86_64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
       debian_buster_arm32v7:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'arm32v7/debian_docker'
         OS_VERSION: 'buster'
         artifactName: 'Linux-Debian-Buster-ARM'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
       debian_buster_arm64v8:
         imageName: 'ubuntu-latest'
         OS_TYPE: 'arm64v8/debian_docker'
         OS_VERSION: 'buster'
         artifactName: 'Linux-Debian-Buster-ARM64'
+        PACKAGE_TO_INSTALL: 'build/*.deb'
   pool:
     vmImage: $(imageName)
   steps:
   - checkout: self
     fetchDepth: 1
     clean: true
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libiioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
   - script: ./CI/travis/before_install_linux
     displayName: "Install Dependencies"
   - script: ./CI/travis/make_linux
@@ -87,10 +106,21 @@ jobs:
 #        artifactName: 'macOS-11.0'
   pool:
     vmImage: $(imageName)
+  variables:
+    PACKAGE_TO_INSTALL: 'build/*.pkg'
   steps:
   - checkout: self
     fetchDepth: 1
     clean: true
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libiioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
   - script: ./CI/travis/before_install_darwin
     displayName: "Install Dependencies"
   - script: ./CI/travis/make_darwin
@@ -125,6 +155,15 @@ jobs:
   - checkout: self
     fetchDepth: 1
     clean: true
+  - task: DownloadPipelineArtifact@2
+    inputs:
+      source: 'specific'
+      project: '$(System.TeamProjectId)'
+      pipeline: $(libiioPipelineId)
+      artifact: '$(artifactName)'
+      runVersion: 'latestFromBranch'
+      runBranch: 'refs/heads/master'
+      path: '$(Agent.BuildDirectory)/s/build/'
   - task: PowerShell@2
     inputs:
       targetType: 'filePath'


### PR DESCRIPTION
Matrix strategy adapted from Travis Collins' work on libiio with Azure Pipelines.
This reduces duplication of the same steps for Linux & Mac builds.

Added artifact publishing. These are pipeline artifacts.
Also, using libiio's artifacts for the build.
For now, we're picking up the latest artifact, but later we may add branch matching (by un-commenting the bits in the yaml file).

Signed-off-by: Alexandru Ardelean <alexandru.ardelean@analog.com>