### PR TITLE
CI: add libserialport to macOS dependencies

### DIFF
--- a/CI/travis/before_install_darwin
+++ b/CI/travis/before_install_darwin
@@ -2,7 +2,7 @@
 
 . CI/travis/lib.sh
 
-brew_install_if_not_exists cmake doxygen libusb libxml2
+brew_install_if_not_exists cmake doxygen libusb libxml2 libserialport
 
 if [ -n "$PACKAGE_TO_INSTALL" ] ; then
 	for file in $PACKAGE_TO_INSTALL ; do


### PR DESCRIPTION
Add libserialport to macOS dependencies.
Without libserialport the `make test` command will fail because it will look for libserialport.0.dylib and not find it.