### PR TITLE
azure_pipelines.yml: add next_stable and libad9361-iio-v0 as trigger

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -6,6 +6,8 @@ trigger:
     include:
     - main
     - master
+    - next_stable
+    - libad9361-iio-v0
     - staging/*
     - 20*
   tags:
@@ -17,6 +19,8 @@ pr:
     include:
     - main
     - master
+    - next_stable
+    - libad9361-iio-v0
     - 20*
 
 jobs:


### PR DESCRIPTION
Two new branches were added on the repository, for this ones the pipeline also needs to be triggered when PRs are raised or commits are pushed.