### PR TITLE
bump cmake_minimum_required to 3.5.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5.0)
 project(ad9361 C)
 
 set(LIBAD9361_VERSION_MAJOR 0)


### PR DESCRIPTION
The newest version of CMake has dropped backwards compatibility for versions lower than 3.5.
