### PR TITLE
Update CMake minimum required version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
 # Lesser General Public License for more details.
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.10)
 project(ad9361 C)
 
 set(LIBAD9361_VERSION_MAJOR 0)


### PR DESCRIPTION
CMake 4 removed compatibility with CMake versions < 3.5, and versions between 3.5-3.10 are deprecated.

This change updates the minimum required version from 2.8.12 to 3.10 to ensure compatibility with modern CMake versions including CMake 4.x.

This issue is affecting NixOS users (see https://github.com/NixOS/nixpkgs/issues/450318) and will likely impact other distributions as they upgrade to CMake 4.x.