### PR TITLE
fmcomms5: port streaming to libiio v1 multi-buffer API

### DIFF
--- a/ad9361_fmcomms5_phase_sync.c
+++ b/ad9361_fmcomms5_phase_sync.c
@@ -335,12 +335,11 @@ int streaming_interfaces(bool enable)
         iio_channel_enable(rxa_chan_imag, dev_rx_mask);
         iio_channel_enable(rxb_chan_real, dev_rx_mask);
         iio_channel_enable(rxb_chan_imag, dev_rx_mask);
-        rxbuf = iio_device_create_buffer(dev_rx, 0, dev_rx_mask);
-        if (iio_err(rxbuf)) {
-            rxbuf = NULL;
+        rxbuf = iio_device_get_buffer(dev_rx, 0);
+        if (!rxbuf) {
             streaming_interfaces(false);
         }
-        dev_rx_stream = iio_buffer_create_stream(rxbuf, 4, SAMPLES);
+        dev_rx_stream = iio_buffer_create_stream(rxbuf, 4, SAMPLES, dev_rx_mask);
         if (iio_err(dev_rx_stream)) {
             dev_rx_stream = NULL;
             streaming_interfaces(false);
@@ -348,9 +347,6 @@ int streaming_interfaces(bool enable)
     } else {
         if (dev_rx_stream) {
             iio_stream_destroy(dev_rx_stream);
-        }
-        if (rxbuf) {
-            iio_buffer_destroy(rxbuf);
         }
         if (rxa_chan_real) {
             iio_channel_disable(rxa_chan_real, dev_rx_mask);

--- a/test/fmcomms5_sync_test.c
+++ b/test/fmcomms5_sync_test.c
@@ -102,12 +102,11 @@ int streaming_interfaces(bool enable)
         iio_channel_enable(rxa_chan_imag, dev_rx_mask);
         iio_channel_enable(rxb_chan_real, dev_rx_mask);
         iio_channel_enable(rxb_chan_imag, dev_rx_mask);
-        rxbuf = iio_device_create_buffer(dev_rx, 0, dev_rx_mask);
-        if (iio_err(rxbuf)) {
-            rxbuf = NULL;
+        rxbuf = iio_device_get_buffer(dev_rx, 0);
+        if (!rxbuf) {
             streaming_interfaces(false);
         }
-        dev_rx_stream = iio_buffer_create_stream(rxbuf, 4, SAMPLES);
+        dev_rx_stream = iio_buffer_create_stream(rxbuf, 4, SAMPLES, dev_rx_mask);
         if (iio_err(dev_rx_stream)) {
             dev_rx_stream = NULL;
             streaming_interfaces(false);
@@ -115,9 +114,6 @@ int streaming_interfaces(bool enable)
     } else {
         if (dev_rx_stream) {
             iio_stream_destroy(dev_rx_stream);
-        }
-        if (rxbuf) {
-            iio_buffer_destroy(rxbuf);
         }
         if (rxa_chan_real) {
             iio_channel_disable(rxa_chan_real, dev_rx_mask);


### PR DESCRIPTION
## PR Description

Port fmcomms5 streaming to the libiio 1.0 multi-buffer API.

### Changes

- Replace `iio_device_create_buffer()` with `iio_device_get_buffer()` in `ad9361_fmcomms5_phase_sync.c` and `test/fmcomms5_sync_test.c`
- Remove `iio_buffer_destroy()` 
- Move channels mask from `iio_device_create_buffer()` to `iio_buffer_create_stream()`, for the new API design
- Fix null check on buffer: `iio_err()`-> `!rxbuf` since `iio_device_get_buffer()` returns NULL, not a pointer-encoded error

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particularly complex or unclear areas
- [x] I have checked that I did not introduce new warnings or errors (CI output)
- [ ] I have checked that components that use libiio did not get broken
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
