### PR TITLE
ci: add monthly scheduled build for libad9361-iio-v0 branch

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,6 +31,14 @@ pr:
     - libad9361-iio-v0
     - 20*
 
+schedules:
+- cron: "0 0 1 * *"
+  displayName: Monthly full build (libad9361-iio-v0)
+  branches:
+    include:
+    - libad9361-iio-v0
+  always: true
+
 jobs:
 - job: LinuxBuilds
   pool:


### PR DESCRIPTION
## PR Description
Ensure the v0 branch gets a full build on the 1st of each month even without new commits, catching upstream dependency changes.

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [ ] I have built libad9361-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
