### PR TITLE
Link ad9361 against libm explicitly

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,7 +107,7 @@ set_target_properties(ad9361 PROPERTIES
 	C_STANDARD_REQUIRED ON
 	C_EXTENSIONS OFF
 )
-target_link_libraries(ad9361 LINK_PRIVATE ${LIBIIO_LIBRARIES})
+target_link_libraries(ad9361 LINK_PRIVATE ${LIBIIO_LIBRARIES} m)
 
 if (MSVC)
 	set_target_properties(ad9361 PROPERTIES OUTPUT_NAME libad9361)


### PR DESCRIPTION
## PR Description

Without this, linking fails on platforms with a strict linker (e.g. OpenBSD's LLD with --no-allow-shlib-undefined), since the math functions used internally (log, sin, cos, pow, etc.) are not resolved automatically like they are via glibc on Linux.

Tested building libad9361-iio 0.4 on OpenBSD 7.9 with Clang 19.1.7.

## PR Type
- [x] Bug fix (a change that fixes an issue)
- [ ] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [x] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [ ] I have commented new code, particulary complex or unclear areas 
- [x] I have built libad9361-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)
