### PR TITLE
cmake: use target_include_directories()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,6 @@ find_path(LIBIIO_INCLUDEDIR iio.h)
 set(LIBAD9361_HEADERS ad9361.h)
 
 file(GLOB_RECURSE FD_SRC_FILES ${CMAKE_CURRENT_SOURCE_DIR}/filterdesigner/*.c)
-include_directories(${CMAKE_CURRENT_SOURCE_DIR} ${LIBIIO_INCLUDEDIR})
 add_library(ad9361 ad9361_multichip_sync.c
             ad9361_baseband_auto_rate.c
             ad9361_design_taps.c
@@ -91,6 +90,7 @@ add_library(ad9361 ad9361_multichip_sync.c
             ad9361_fmcomms5_phase_sync.c
             ${FD_SRC_FILES}
             ${LIBAD9361_HEADERS})
+target_include_directories(ad9361 PUBLIC ${CMAKE_CURRENT_SOURCE_DIR} PRIVATE ${LIBIIO_INCLUDEDIR})
 
 option(BUILD_TESTS "Build tests" ON)
 if (BUILD_TESTS)


### PR DESCRIPTION
## PR Description

Replace `include_directories()` with `target_include_directories()`.

From [CMake's `include_directories()` documentation](https://cmake.org/cmake/help/latest/command/include_directories.html):

> Prefer the target_include_directories() command to add include
directories to individual targets and optionally
propagate/export them to dependents.

The change has been tested with FetchContent (simplified):

```
include(FetchContent)
fetchcontent_declare(ad9361 GIT_REPOSITORY <url> GIT_TAG <tag>)
fetchcontent_makeavailable(ad9361)
add_library(mylib mylib.c)
target_link_libraries(mylib PRIVATE ad9361)
```

Without this change a compile time error occurs:
```shell
mylib.c:5:10: fatal error: ad9361.h: No such file or directory
```

## PR Type
- [ ] Bug fix (a change that fixes an issue)
- [x] New feature (a change that adds new functionality)
- [ ] Breaking change (a change that affects other repos or cause CIs to fail)

## PR Checklist
- [ ] I have followed the coding standards and guidelines
- [x] I have conducted a self-review of my own code changes
- [x] I have commented new code, particulary complex or unclear areas 
- [x] I have built libad9361-iio and check no new warnings/errors were introduced
- [ ] I have checked that my changes did not broke components that use libad9361-iio as dependency
- [ ] I have updated the documentation accordingly (GitHub Pages, READMEs, etc)

